### PR TITLE
Load model names from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,21 @@ This project provides a minimal Flask web interface backed by [LangChain](https:
 pip install -r requirements.txt
 ```
 
-2. Edit `config.json` with your API keys and desired provider.
+2. Edit `config.json` with your API keys, desired provider, and model names. Each provider's model is specified under a `models` mapping:
+
+```json
+{
+  "provider": "openai",
+  "models": {
+    "openai": "gpt-4o-mini",
+    "gemini": "gemini-pro",
+    "anthropic": "claude-3-haiku"
+  },
+  "openai_api_key": "YOUR_OPENAI_KEY",
+  "gemini_api_key": "YOUR_GEMINI_KEY",
+  "anthropic_api_key": "YOUR_ANTHROPIC_KEY"
+}
+```
 
 3. Run the application:
 

--- a/config.json
+++ b/config.json
@@ -1,5 +1,10 @@
 {
   "provider": "openai",
+  "models": {
+    "openai": "gpt-4o-mini",
+    "gemini": "gemini-pro",
+    "anthropic": "claude-3-haiku"
+  },
   "openai_api_key": "YOUR_OPENAI_KEY",
   "gemini_api_key": "YOUR_GEMINI_KEY",
   "anthropic_api_key": "YOUR_ANTHROPIC_KEY"

--- a/langchain_chat.py
+++ b/langchain_chat.py
@@ -30,15 +30,24 @@ class ChatHandler:
         self.history: List[Dict[str, str]] = self._load_history()
 
     def _load_model(self):
+        models = self.config.get("models", {})
+        model_name = models.get(self.provider)
+        if not model_name:
+            raise ValueError(f"Model not specified for provider: {self.provider}")
+
         if self.provider == "openai":
-            return ChatOpenAI(openai_api_key=self.config.get("openai_api_key"))
+            return ChatOpenAI(
+                model=model_name,
+                openai_api_key=self.config.get("openai_api_key"),
+            )
         if self.provider == "gemini" and ChatGoogleGenerativeAI is not None:
             return ChatGoogleGenerativeAI(
                 google_api_key=self.config.get("gemini_api_key"),
-                model="gemini-pro",
+                model=model_name,
             )
         if self.provider == "anthropic":
             return ChatAnthropic(
+                model=model_name,
                 anthropic_api_key=self.config.get("anthropic_api_key"),
             )
         raise ValueError(f"Unsupported provider: {self.provider}")


### PR DESCRIPTION
## Summary
- allow selecting model per provider via `config.json`
- document provider model configuration in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py langchain_chat.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab4d7b6c78832ebd4e93b16771c700