### PR TITLE
feat: add frontend model selection and token usage tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,12 +12,27 @@ def index():
         if user_message:
             chat_handler.chat(user_message)
         return redirect(url_for("index"))
-    return render_template("index.html", history=chat_handler.history, provider=chat_handler.provider)
+    return render_template(
+        "index.html",
+        history=chat_handler.history,
+        provider=chat_handler.provider,
+        models=chat_handler.available_models(),
+        current_model=chat_handler.current_model,
+        tokens=chat_handler.token_usage,
+    )
 
 
 @app.route("/reset")
 def reset():
     chat_handler.reset_history()
+    return redirect(url_for("index"))
+
+
+@app.route("/set_model", methods=["POST"])
+def set_model():
+    model = request.form.get("model")
+    if model:
+        chat_handler.set_model(model)
     return redirect(url_for("index"))
 
 

--- a/langchain_chat.py
+++ b/langchain_chat.py
@@ -1,8 +1,9 @@
 import json
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, Tuple
 
 from langchain.schema import HumanMessage, AIMessage
+from langchain_community.callbacks.manager import get_openai_callback
 try:
     from langchain_openai import ChatOpenAI
 except ImportError:  # fallback for older langchain versions
@@ -25,13 +26,18 @@ class ChatHandler:
 
     def __init__(self) -> None:
         self.config: Dict[str, str] = json.loads(CONFIG_PATH.read_text())
+        self.models: Dict[str, str] = self.config.get("models", {})
+        self.model_provider: Dict[str, str] = {
+            model: prov for prov, model in self.models.items()
+        }
         self.provider: str = self.config.get("provider", "openai")
+        self.current_model: str = self.models.get(self.provider, "")
         self.llm = self._load_model()
         self.history: List[Dict[str, str]] = self._load_history()
+        self.token_usage: Dict[str, int] = {"read": 0, "created": 0, "cache": 0}
 
     def _load_model(self):
-        models = self.config.get("models", {})
-        model_name = models.get(self.provider)
+        model_name = self.current_model
         if not model_name:
             raise ValueError(f"Model not specified for provider: {self.provider}")
 
@@ -66,11 +72,44 @@ class ChatHandler:
             HumanMessage(m["content"]) if m["role"] == "user" else AIMessage(m["content"])
             for m in self.history
         ]
-        response = self.llm(messages)
+        if self.provider == "openai":
+            with get_openai_callback() as cb:
+                response = self.llm.invoke(messages)
+            read, created, cache = cb.prompt_tokens, cb.completion_tokens, cb.prompt_tokens_cached
+        else:
+            response = self.llm.invoke(messages)
+            read, created, cache = self._extract_usage(response)
+        self.token_usage["read"] += read
+        self.token_usage["created"] += created
+        self.token_usage["cache"] += cache
         self.history.append({"role": "assistant", "content": response.content})
         self._save_history()
         return response.content
 
+    def _extract_usage(self, response) -> Tuple[int, int, int]:
+        metadata = getattr(response, "response_metadata", {})
+        usage = metadata.get("token_usage", {})
+        read = usage.get("prompt_tokens") or usage.get("input_tokens") or 0
+        created = usage.get("completion_tokens") or usage.get("output_tokens") or 0
+        cache = (
+            usage.get("prompt_tokens_details", {}).get("cached_tokens", 0)
+            if isinstance(usage.get("prompt_tokens_details"), dict)
+            else usage.get("cached_tokens", 0)
+        )
+        return read, created, cache
+
+    def available_models(self) -> List[str]:
+        return list(self.model_provider.keys())
+
+    def set_model(self, model_name: str) -> None:
+        provider = self.model_provider.get(model_name)
+        if not provider:
+            raise ValueError(f"Unknown model: {model_name}")
+        self.provider = provider
+        self.current_model = model_name
+        self.llm = self._load_model()
+
     def reset_history(self) -> None:
         self.history = []
+        self.token_usage = {"read": 0, "created": 0, "cache": 0}
         self._save_history()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ langchain
 langchain-openai
 langchain-google-genai
 langchain-anthropic
+langchain-community
 openai
 anthropic
 google-generativeai

--- a/static/style.css
+++ b/static/style.css
@@ -29,6 +29,9 @@ body {
 .message.assistant {
   background: #e8f5e9;
 }
+.model-form {
+  margin-bottom: 10px;
+}
 .input-form {
   display: flex;
   gap: 10px;
@@ -48,6 +51,11 @@ body {
 }
 .input-form .reset {
   background: #9e9e9e;
+}
+.tokens {
+  margin-top: 10px;
+  font-size: 0.9em;
+  color: #555;
 }
 .placeholder {
   color: #777;

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,15 @@
 </head>
 <body>
   <div class="chat-container">
-    <h1>LangChain Chat ({{ provider }})</h1>
+    <h1>LangChain Chat ({{ provider }} - {{ current_model }})</h1>
+    <form method="post" action="{{ url_for('set_model') }}" class="model-form">
+      <select name="model">
+        {% for m in models %}
+          <option value="{{ m }}" {% if m == current_model %}selected{% endif %}>{{ m }}</option>
+        {% endfor %}
+      </select>
+      <button type="submit">Switch</button>
+    </form>
     <div class="history">
       {% for msg in history %}
         <div class="message {{ msg.role }}">
@@ -20,8 +28,11 @@
     <form method="post" class="input-form">
       <input type="text" name="message" placeholder="Type your message" required />
       <button type="submit">Send</button>
-      <a class="reset" href="{{ url_for('reset') }}">Reset</a>
+      <a class="reset" href="{{ url_for('reset') }}">Reset History</a>
     </form>
+    <div class="tokens">
+      Tokens - Read: {{ tokens.read }}, Created: {{ tokens.created }}, Cache: {{ tokens.cache }}
+    </div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow selecting models from the UI and auto-configure the provider
- track token usage per chat and reset with history
- display model selector, token counter, and reset history button in frontend

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab5af67fe8832e9d8e2c415fe66169