### PR TITLE
feat: add expert mode with editable system prompt

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,6 +19,9 @@ def index():
         models=chat_handler.available_models(),
         current_model=chat_handler.current_model,
         tokens=chat_handler.token_usage,
+        expert_mode=chat_handler.use_expert_mode,
+        system_prompt=chat_handler.last_system_prompt,
+        system_prompt_template=chat_handler.system_prompt_template,
     )
 
 
@@ -33,6 +36,20 @@ def set_model():
     model = request.form.get("model")
     if model:
         chat_handler.set_model(model)
+    return redirect(url_for("index"))
+
+
+@app.route("/toggle_mode", methods=["POST"])
+def toggle_mode():
+    chat_handler.use_expert_mode = request.form.get("expert_mode") == "true"
+    return redirect(url_for("index"))
+
+
+@app.route("/set_prompt", methods=["POST"])
+def set_prompt():
+    prompt = request.form.get("prompt_template")
+    if prompt is not None:
+        chat_handler.set_system_prompt_template(prompt)
     return redirect(url_for("index"))
 
 

--- a/config.json
+++ b/config.json
@@ -7,5 +7,6 @@
   },
   "openai_api_key": "YOUR_OPENAI_KEY",
   "gemini_api_key": "YOUR_GEMINI_KEY",
-  "anthropic_api_key": "YOUR_ANTHROPIC_KEY"
+  "anthropic_api_key": "YOUR_ANTHROPIC_KEY",
+  "system_prompt_template": "Given the conversation history and the user's question, write a concise system prompt describing the expert who should answer.\nHistory:\n{history}\nQuestion: {question}\nSystem prompt:"
 }

--- a/static/style.css
+++ b/static/style.css
@@ -6,12 +6,26 @@ body {
   padding-top: 40px;
 }
 .chat-container {
-  width: 80%;
-  max-width: 700px;
+  width: 90%;
+  max-width: 1000px;
+  display: flex;
+  gap: 20px;
+}
+.chat-main {
+  flex: 2;
   background: #fff;
   padding: 20px;
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+.side-panel {
+  flex: 1;
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  max-height: 600px;
+  overflow-y: auto;
 }
 .history {
   max-height: 400px;
@@ -30,6 +44,9 @@ body {
   background: #e8f5e9;
 }
 .model-form {
+  margin-bottom: 10px;
+}
+.mode-form {
   margin-bottom: 10px;
 }
 .input-form {
@@ -56,6 +73,17 @@ body {
   margin-top: 10px;
   font-size: 0.9em;
   color: #555;
+}
+.system-prompt {
+  white-space: pre-wrap;
+  background: #f0f0f0;
+  padding: 10px;
+  border-radius: 4px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.prompt-form textarea {
+  width: 100%;
 }
 .placeholder {
   color: #777;

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,31 +7,49 @@
 </head>
 <body>
   <div class="chat-container">
-    <h1>LangChain Chat ({{ provider }} - {{ current_model }})</h1>
-    <form method="post" action="{{ url_for('set_model') }}" class="model-form">
-      <select name="model">
-        {% for m in models %}
-          <option value="{{ m }}" {% if m == current_model %}selected{% endif %}>{{ m }}</option>
+    <div class="chat-main">
+      <h1>LangChain Chat ({{ provider }} - {{ current_model }})</h1>
+      <form method="post" action="{{ url_for('set_model') }}" class="model-form">
+        <select name="model">
+          {% for m in models %}
+            <option value="{{ m }}" {% if m == current_model %}selected{% endif %}>{{ m }}</option>
+          {% endfor %}
+        </select>
+        <button type="submit">Switch</button>
+      </form>
+      <div class="history">
+        {% for msg in history %}
+          <div class="message {{ msg.role }}">
+            <strong>{{ msg.role }}:</strong> {{ msg.content }}
+          </div>
+        {% else %}
+          <p class="placeholder">No conversation yet.</p>
         {% endfor %}
-      </select>
-      <button type="submit">Switch</button>
-    </form>
-    <div class="history">
-      {% for msg in history %}
-        <div class="message {{ msg.role }}">
-          <strong>{{ msg.role }}:</strong> {{ msg.content }}
-        </div>
-      {% else %}
-        <p class="placeholder">No conversation yet.</p>
-      {% endfor %}
+      </div>
+      <form method="post" class="input-form">
+        <input type="text" name="message" placeholder="Type your message" required />
+        <button type="submit">Send</button>
+        <a class="reset" href="{{ url_for('reset') }}">Reset History</a>
+      </form>
+      <div class="tokens">
+        Tokens - Read: {{ tokens.read }}, Created: {{ tokens.created }}, Cache: {{ tokens.cache }}
+      </div>
     </div>
-    <form method="post" class="input-form">
-      <input type="text" name="message" placeholder="Type your message" required />
-      <button type="submit">Send</button>
-      <a class="reset" href="{{ url_for('reset') }}">Reset History</a>
-    </form>
-    <div class="tokens">
-      Tokens - Read: {{ tokens.read }}, Created: {{ tokens.created }}, Cache: {{ tokens.cache }}
+    <div class="side-panel">
+      <form method="post" action="{{ url_for('toggle_mode') }}" class="mode-form">
+        <input type="hidden" name="expert_mode" value="false" />
+        <label>
+          <input type="checkbox" name="expert_mode" value="true" {% if expert_mode %}checked{% endif %} onchange="this.form.submit()" />
+          Expert mode
+        </label>
+      </form>
+      <h2>Current System Prompt</h2>
+      <pre class="system-prompt">{{ system_prompt or 'N/A' }}</pre>
+      <h3>System Prompt Builder</h3>
+      <form method="post" action="{{ url_for('set_prompt') }}" class="prompt-form">
+        <textarea name="prompt_template" rows="10">{{ system_prompt_template }}</textarea>
+        <button type="submit">Save</button>
+      </form>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- add expert mode that builds a system prompt for an expert before answering
- display and allow editing of the system prompt template in the UI
- persist system prompt template in config.json

## Testing
- `python -m py_compile app.py langchain_chat.py`
- `python -m json.tool config.json > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68ab637b4f78832e8fb6303155d283d8