### PR TITLE
Fix expert mode toggle

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,7 +41,7 @@ def set_model():
 
 @app.route("/toggle_mode", methods=["POST"])
 def toggle_mode():
-    chat_handler.use_expert_mode = request.form.get("expert_mode") == "true"
+    chat_handler.use_expert_mode = "true" in request.form.getlist("expert_mode")
     return redirect(url_for("index"))
 
 


### PR DESCRIPTION
## Summary
- ensure expert mode checkbox state persists by correctly reading form values

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab6b6553d8832ea568e2bfd3eb39af