### PR TITLE
Add loading indicator for message send action

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('.input-form');
+  const overlay = document.getElementById('loading-overlay');
+  if (!form || !overlay) return;
+  const sendButton = form.querySelector('button[type="submit"]');
+  const messageInput = form.querySelector('input[name="message"]');
+  const loadingText = document.getElementById('loading-text');
+  const expertCheckbox = document.querySelector('.mode-form input[name="expert_mode"][type="checkbox"]');
+  form.addEventListener('submit', () => {
+    overlay.classList.remove('hidden');
+    if (sendButton) sendButton.disabled = true;
+    if (messageInput) messageInput.disabled = true;
+    if (loadingText) {
+      if (expertCheckbox && expertCheckbox.checked) {
+        loadingText.textContent = 'Creating expert prompt...';
+        setTimeout(() => {
+          loadingText.textContent = 'Generating response...';
+        }, 1000);
+      } else {
+        loadingText.textContent = 'Generating response...';
+      }
+    }
+  });
+});

--- a/static/style.css
+++ b/static/style.css
@@ -88,3 +88,41 @@ body {
 .placeholder {
   color: #777;
 }
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.8);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.5em;
+  color: #555;
+  z-index: 1000;
+}
+
+.loading-overlay .spinner {
+  border: 4px solid #ccc;
+  border-top: 4px solid #1976d2;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+  margin-bottom: 10px;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.hidden {
+  display: none;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,10 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
 </head>
 <body>
+  <div id="loading-overlay" class="loading-overlay hidden">
+    <div class="spinner"></div>
+    <p id="loading-text">Processing...</p>
+  </div>
   <div class="chat-container">
     <div class="chat-main">
       <h1>LangChain Chat ({{ provider }} - {{ current_model }})</h1>
@@ -52,5 +56,6 @@
       </form>
     </div>
   </div>
+  <script src="{{ url_for('static', filename='script.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show a full-screen overlay while a message is being sent
- display step-wise status text (creating expert prompt, generating response)
- include spinner and disable message inputs during processing

## Testing
- `python -m py_compile app.py langchain_chat.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab7069e40c832eb50aff3ef847e53f