### PR TITLE
Support multi-model providers

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ def index():
         history=chat_handler.history,
         provider=chat_handler.provider,
         models=chat_handler.available_models(),
+        model_provider=chat_handler.model_provider,
         current_model=chat_handler.current_model,
         tokens=chat_handler.token_usage,
         expert_mode=chat_handler.use_expert_mode,

--- a/config.json
+++ b/config.json
@@ -1,12 +1,43 @@
 {
   "provider": "openai",
   "models": {
-    "openai": "gpt-4o-mini",
-    "gemini": "gemini-pro",
-    "anthropic": "claude-3-haiku"
+    "openai": [
+      "gpt-5",
+      "gpt-5-mini",
+      "gpt-5-nano",
+      "gpt-4.1",
+      "gpt-4.1-mini",
+      "gpt-4.1-nano",
+      "gpt-4o",
+      "gpt-4o-mini",
+      "o3",
+      "o3-mini",
+      "o4-mini",
+      "o3-deep-research"
+    ],
+    "gemini": [
+      "gemini-2.5-pro",
+      "gemini-2.5-flash",
+      "gemini-2.5-flash-lite",
+      "gemini-live-2.5-flash-preview",
+      "gemini-2.5-flash-preview-tts",
+      "gemini-2.5-pro-preview-tts",
+      "gemini-2.0-flash",
+      "gemini-2.0-flash-lite",
+      "gemini-2.0-flash-live-001",
+      "gemini-2.0-flash-preview-image-generation"
+    ],
+    "anthropic": [
+      "claude-opus-4-1-20250805",
+      "claude-opus-4-20250514",
+      "claude-sonnet-4-20250514",
+      "claude-3-7-sonnet-20250219",
+      "claude-3-5-haiku-20241022",
+      "claude-3-haiku-20240307"
+    ]
   },
-  "openai_api_key": "YOUR_OPENAI_KEY",
-  "gemini_api_key": "YOUR_GEMINI_KEY",
-  "anthropic_api_key": "YOUR_ANTHROPIC_KEY",
+  "openai_api_key": "",
+  "gemini_api_key": "",
+  "anthropic_api_key": "",
   "system_prompt_template": "Given the conversation history and the user's question, write a concise system prompt describing the expert who should answer.\nHistory:\n{history}\nQuestion: {question}\nSystem prompt:"
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
       <form method="post" action="{{ url_for('set_model') }}" class="model-form">
         <select name="model">
           {% for m in models %}
-            <option value="{{ m }}" {% if m == current_model %}selected{% endif %}>{{ m }}</option>
+            <option value="{{ m }}" {% if m == current_model %}selected{% endif %}>{{ m }} ({{ model_provider[m] }})</option>
           {% endfor %}
         </select>
         <button type="submit">Switch</button>


### PR DESCRIPTION
## Summary
- Support multiple models per provider in `ChatHandler`
- Expose provider mapping and show provider with each model in the UI
- Expand `config.json` to list all supported OpenAI, Gemini, and Anthropic models

## Testing
- `python -m py_compile app.py langchain_chat.py`
- `python -m json.tool config.json | head -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68ab76da518c832ea3aabe66e09ac186