### PR TITLE
Handle chat errors and surface in UI

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -43,6 +43,10 @@ body {
 .message.assistant {
   background: #e8f5e9;
 }
+.message.error {
+  background: #ffebee;
+  color: #b71c1c;
+}
 .model-form {
   margin-bottom: 10px;
 }


### PR DESCRIPTION
## Summary
- log and display provider errors in chat history
- add red styling for error messages

## Testing
- `python -m py_compile langchain_chat.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab7c707124832ebf64df227ad8f59f