### PR TITLE
Fix message field disabling during form submission

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -9,7 +9,13 @@ document.addEventListener('DOMContentLoaded', () => {
   form.addEventListener('submit', () => {
     overlay.classList.remove('hidden');
     if (sendButton) sendButton.disabled = true;
-    if (messageInput) messageInput.disabled = true;
+    // Keep the message input enabled during submission so its value is sent
+    // Disable it asynchronously once the submission has started
+    if (messageInput) {
+      setTimeout(() => {
+        messageInput.disabled = true;
+      }, 0);
+    }
     if (loadingText) {
       if (expertCheckbox && expertCheckbox.checked) {
         loadingText.textContent = 'Creating expert prompt...';


### PR DESCRIPTION
## Summary
- Keep message input enabled during form submit so its text is sent
- Disable the input after submission begins to preserve user text

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aba852d4f8832e82ed0cc8917ef7ca